### PR TITLE
Fix getColorFromResolution index limits check

### DIFF
--- a/add_em_res.js
+++ b/add_em_res.js
@@ -82,8 +82,8 @@ function getColorFromResolution(resolution){
   let highRes = Math.floor(resolution);
   let lowRes = highRes +1;
 
-  const highResColor = emResColors.length < highRes ? emResColors[emResColors.length-1] : emResColors[highRes];
-  const lowResColor = emResColors.length < lowRes ? emResColors[emResColors.length-1] : emResColors[lowRes];
+  const highResColor = emResColors.length <= highRes ? emResColors[emResColors.length-1] : emResColors[highRes];
+  const lowResColor = emResColors.length <= lowRes ? emResColors[emResColors.length-1] : emResColors[lowRes];
 
   // get the
   return getColorBetween(highResColor, lowResColor, resolution-highRes)


### PR DESCRIPTION
Fixes console error at `extendProtVista.bundle.js`: `Uncaught TypeError: Cannot read property 'substring' of undefined`

I've not updated `extendProtVista.bundle.js` as it seems it's not up-to-date to the source JS files (there is a lengthy diff), should I do it? Btw, is this dist file really needed in the repo?
